### PR TITLE
Fix vbguest error

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ per avviare le VM basta lanciare un singolo comando!
 ```bash
 cd vagrant
 vagrant plugin install vagrant-vbguest
+vagrant vbguest
 vagrant up
 ```
 


### PR DESCRIPTION
Mi dava questo errore:

```
Vagrant was unable to mount VirtualBox shared folders. This is usually
because the filesystem "vboxsf" is not available. This filesystem is
made available via the VirtualBox Guest Additions and kernel module.
Please verify that these guest additions are properly installed in the
guest. This is not a bug in Vagrant and is usually caused by a faulty
Vagrant box. For context, the command attempted was:

mount -t vboxsf -o dmode=700,fmode=600,uid=1000,gid=1000 ansible /ansible

The error output from the command was:

/sbin/mount.vboxsf: mounting failed with the error: No such device
```

Per risolverlo ho aggiunto la riga:

```
vagrant vbguest
```

Alle istruzioni.
